### PR TITLE
add psutil as a runtime dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,4 +6,5 @@
   <maintainer email="alex@alex.com">Alex Spitzer</maintainer>
   <license>MIT</license>
   <buildtool_depend>catkin</buildtool_depend>
+  <exec_depend>python-psutil</exec_depend>
 </package>


### PR DESCRIPTION
Add psutil as a runtime dependency. This allows rosdep to discover and install it when needed.